### PR TITLE
ApmPreInit: fix const warning

### DIFF
--- a/src/apm_driver.c
+++ b/src/apm_driver.c
@@ -351,7 +351,6 @@ ApmPreInit(ScrnInfoPtr pScrn, int flags)
     EntityInfoPtr	pEnt;
     vgaHWPtr		hwp;
     MessageType		from;
-    char		*mod = NULL;
     const char		*s;
     ClockRangePtr	clockRanges;
     int			i;
@@ -972,6 +971,7 @@ ApmPreInit(ScrnInfoPtr pScrn, int flags)
     xf86SetDpi(pScrn, 0, 0);
 
     /* Load bpp-specific modules */
+    const char *mod = NULL;
     switch (pScrn->bitsPerPixel) {
     case 8:
     case 16:


### PR DESCRIPTION
The `mod` field is only assigned a literal (readonly data), so needs to be const.