### PR TITLE
don't include <opaque.h>

### DIFF
--- a/src/apm_driver.c
+++ b/src/apm_driver.c
@@ -9,7 +9,6 @@
 #include "xf86int10.h"
 #include "vbe.h"
 
-#include "opaque.h"
 #ifdef HAVE_XEXTPROTO_71
 #include <X11/extensions/dpmsconst.h>
 #else


### PR DESCRIPTION
Don't need anything from it, so no need to include it at all.